### PR TITLE
Version 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uuid-utils"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
### Added

* Add `getnode` function by @aminalaee in https://github.com/aminalaee/uuid-utils/pull/34
* Update wheels for Python 3.12 by @aminalaee in https://github.com/aminalaee/uuid-utils/pull/36
* Add `compat` module to return std library UUID by @aminalaee in https://github.com/aminalaee/uuid-utils/pull/38

**Full Changelog**: https://github.com/aminalaee/uuid-utils/compare/0.5.0...0.6.0