### PR TITLE
Export UUID in the compat module

### DIFF
--- a/python/uuid_utils/compat/__init__.py
+++ b/python/uuid_utils/compat/__init__.py
@@ -1,4 +1,4 @@
-import uuid
+from uuid import UUID
 
 import uuid_utils
 
@@ -8,24 +8,24 @@ def uuid1(node=None, clock_seq=None):
     If 'node' is not given, getnode() is used to obtain the hardware
     address.  If 'clock_seq' is given, it is used as the sequence number;
     otherwise a random 14-bit sequence number is chosen."""
-    return uuid.UUID(int=uuid_utils.uuid1(node, clock_seq).int)
+    return UUID(int=uuid_utils.uuid1(node, clock_seq).int)
 
 
 def uuid3(namespace, name):
     """Generate a UUID from the MD5 hash of a namespace UUID and a name."""
     namespace = uuid_utils.UUID(namespace.hex) if namespace else namespace
-    return uuid.UUID(int=uuid_utils.uuid3(namespace, name).int)
+    return UUID(int=uuid_utils.uuid3(namespace, name).int)
 
 
 def uuid4():
     """Generate a random UUID."""
-    return uuid.UUID(int=uuid_utils.uuid4().int)
+    return UUID(int=uuid_utils.uuid4().int)
 
 
 def uuid5(namespace, name):
     """Generate a UUID from the SHA-1 hash of a namespace UUID and a name."""
     namespace = uuid_utils.UUID(namespace.hex) if namespace else namespace
-    return uuid.UUID(int=uuid_utils.uuid5(namespace, name).int)
+    return UUID(int=uuid_utils.uuid5(namespace, name).int)
 
 
 def uuid6(node=None, timestamp=None):
@@ -33,14 +33,14 @@ def uuid6(node=None, timestamp=None):
     This is similar to version 1 UUIDs,
     except that it is lexicographically sortable by timestamp.
     """
-    return uuid.UUID(int=uuid_utils.uuid6(node, timestamp).int)
+    return UUID(int=uuid_utils.uuid6(node, timestamp).int)
 
 
 def uuid7(timestamp=None):
     """Generate a version 7 UUID using a time value and random bytes."""
-    return uuid.UUID(int=uuid_utils.uuid7(timestamp).int)
+    return UUID(int=uuid_utils.uuid7(timestamp).int)
 
 
 def uuid8(bytes):
     """Generate a custom UUID comprised almost entirely of user-supplied bytes.."""
-    return uuid.UUID(bytes=uuid_utils.uuid8(bytes).bytes)
+    return UUID(bytes=uuid_utils.uuid8(bytes).bytes)


### PR DESCRIPTION
First of all thank you for this great package.

I had an issue at first when trying to use this with pydantic:

```
pydantic.errors.PydanticSchemaGenerationError: Unable to generate pydantic-core schema for <class 'uuid_utils.UUID'>. Set `arbitrary_types_allowed=True` in the model_config to ignore this error or implement `__get_pydantic_core_schema__` on your type to fully support it.

If you got this error by calling handler(<some type>) within `__get_pydantic_core_schema__` then you likely need to call `handler.generate_schema(<some type>)` since we do not call `__get_pydantic_core_schema__` on `<some type>` otherwise to avoid infinite recursion.

For further information visit https://errors.pydantic.dev/2.7/u/schema-for-unknown-type
```

I was going to suggest adding support for `__get_pydantic_core_schema__` but then I saw #32 and thought it best to just use the compat version.

However, the compat package doesn't export UUID like the normal one. That's what this PR adds. So one can do `import uuid_utils.compat as uuid` and act as if it was the built-in uuid.

There are other exports in the main `__all__` that are also missing (namespaces, reserved, and getnode). Those I've never used but I would see the point in exporting the exact same list.