### PR TITLE
Version 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uuid-utils"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
### Added
* Add optional `nanos` argument to `uuid6` and `uuid7` by @cstruct in https://github.com/aminalaee/uuid-utils/pull/51
* Make `uuid3` and `uuid5` compatible with Python 3.12 by @aminalaee in https://github.com/aminalaee/uuid-utils/pull/56
* Improve `compat` typings by @aminalaee in https://github.com/aminalaee/uuid-utils/pull/55

## New Contributors
* @moritzwilksch made their first contribution in https://github.com/aminalaee/uuid-utils/pull/48
* @cstruct made their first contribution in https://github.com/aminalaee/uuid-utils/pull/51

**Full Changelog**: https://github.com/aminalaee/uuid-utils/compare/0.7.0...0.8.0