### PR TITLE
build: use abi3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 mac_address = "1.1.7"
-pyo3 = { version = "0.22.0", features = ["extension-module", "generate-import-lib"] }
+pyo3 = { version = "0.22.0", features = ["extension-module", "generate-import-lib", 'abi3-py38'] }
 rand = "0.8.5"
 uuid = { version = "1.9.1", features = ["v1", "v3", "v4", "v5", "v6", "v7", "v8", "fast-rng"]}


### PR DESCRIPTION
this project doesn't use any non-stable API, so it's possible to build a abi3 wheel. https://docs.python.org/3/c-api/stable.html

With abi3, we dont' need to build wheel for all py38/39/310/311/312 , but abi3-py38 only, and it will work on all CPython >= py38.

Which means, if new CPython version is release, we do not need to build this wheel again for new CPython, abi3-py38 still works for new CPython.