### PR TITLE
fix: return version None for non-RFC UUIDs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,8 +162,8 @@ impl UUID {
     }
 
     #[getter]
-    fn version(&self) -> usize {
-        self.uuid.get_version_num()
+    fn version(&self) -> Option<usize> {
+        (self.uuid.get_variant() == Variant::RFC4122).then(|| self.uuid.get_version_num())
     }
 
     #[getter]

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -151,6 +151,11 @@ def test_uuid_version(version: int) -> None:
     assert uuid.version == version
 
 
+def test_uuid_version_none_for_non_rfc4122() -> None:
+    uuid = uuid_utils.UUID(int=0)
+    assert uuid.version is None
+
+
 def test_uuid_illegal_version() -> None:
     with pytest.raises(ValueError):
         uuid_utils.UUID("a8098c1a-f86e-11da-bd1a-00112444be1e", version=0)


### PR DESCRIPTION
Return `None` for non-RFC UUIDs instead of `0` to be compatible with stdlib.