### PR TITLE
Version 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "uuid-utils"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash",
  "mac_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uuid-utils"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## What's Changed
* Optimize uuid_utils.compat with `from_int` by @aminalaee in https://github.com/aminalaee/uuid-utils/pull/166
* fix: return version None for non-RFC UUIDs by @aminalaee in https://github.com/aminalaee/uuid-utils/pull/163
* Validate `node` argument out of range in constructor by @aminalaee in https://github.com/aminalaee/uuid-utils/pull/164
* Drop Python3.9 by @aminalaee in https://github.com/aminalaee/uuid-utils/pull/168


**Full Changelog**: https://github.com/aminalaee/uuid-utils/compare/0.15.0...0.16.0