### PR TITLE
Add PyPI publish attestations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,14 +382,18 @@ jobs:
       ]
     steps:
       - uses: actions/download-artifact@v8
+        with:
+          path: release-dist
+          pattern: wheels-*
+          merge-multiple: true
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: "wheels-*/*"
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
+          subject-path: "release-dist/*"
       - name: Publish to PyPI
-        run: uv publish 'wheels-*/*'
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          packages-dir: release-dist
 
   docs:
     name: Publish docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           packages-dir: release-dist
+          skip-existing: true
+          verbose: true
 
   docs:
     name: Publish docs


### PR DESCRIPTION
### Summary

Hi! This switches the release upload step from `uv publish` to `pypa/gh-action-pypi-publish@v1.14.0`.

`uuid-utils` already publishes from GitHub Actions using PyPI Trusted Publishing/OIDC. Using the official PyPA publish action keeps that flow, but also generates and uploads PyPI publish attestations by default, so this should not require any new PyPI-side configuration or secrets.

The workflow already generates GitHub artifact attestations with `actions/attest-build-provenance`, and this PR leaves that in place. This change adds _PyPI-hosted_ publish attestations, which bind each uploaded distribution to the GitHub Actions workflow that published it and make that provenance available through PyPI for downstream users and tooling.

### Possible follow-ups

I kept this PR intentionally small for reviewability, but noticed a few related release-hardening opportunities while looking at the workflow:

- Pin GitHub Actions to full commit SHAs.
- Avoid cache use in release artifact builds.
- Split build and publish into separate jobs, so `id-token: write` is only available in the final upload job.

### Testing

Not run; workflow-only change.